### PR TITLE
docs: reference correct module output name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Please keep in mind this repo is WIP and its interface is subject to change (pro
 
 The general idea is:
 - Either add the repo to your flake inputs (and pass on `nix-colors` to your home config), or use `fetchTarball` to grab it on a legacy setup.
-- Import the module `nix-colors.homeConfigurationModule`
+- Import the module `nix-colors.homeManagerModule`
 - Set the option `colorscheme` to your preferred color scheme (such as `nix-colors.colorSchemes.dracula`)
 - Use `config.colorscheme.colors.base0X` to refer to any of the 16 colors from anywhere!
 


### PR DESCRIPTION
The currently-suggested flake output of `homeConfigurationModule` does not exist.