### PR TITLE
Improve documentation and correctly export to non-flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ nix-channel --add https://github.com/misterio77/nix-colors/archive/main.tar.gz n
 nix-channel --update
 ```
 
-Then, at the top of your config file(s) add `nix-colors ? <nix-colors>` as arguments (instead of just `nix-colors`).
+Then, at the top of your config file(s) add `nix-colors ? <nix-colors>` as an argument (instead of just `nix-colors`).
 
 ## Using
 
-With that done, move to your home manager configuration.
+With that done, move on to your home manager configuration.
 
 You should import the `nix-colors.homeManagerModule`, and set the option `colorscheme` to your preferred scheme, such as `nix-colors.colorSchemes.dracula`
 
@@ -66,7 +66,7 @@ Here's a quick example on how to use it with, say, a terminal emulator (kitty) a
       settings = {
         foreground = "#${config.colorscheme.colors.base05}";
         background = "#${config.colorscheme.colors.base00}";
-        # There's a lot more than just fg and bg...
+        # ...
       };
     };
     qutebrowser = {
@@ -76,7 +76,7 @@ Here's a quick example on how to use it with, say, a terminal emulator (kitty) a
         webppage.preferred_color_scheme = "${config.colorscheme.kind}";
         tabs.bar.bg = "#${config.colorscheme.colors.base00}";
         keyhint.fg = "#${config.colorscheme.colors.base05}";
-        # A lot more...
+        # ...
       };
     };
   };

--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ Once you do, you can access the color schemes with `nix-colors.colorSchemes`, an
 
 ### Legacy (non-flake)
 If you're not using flakes, just go to the top of your configuration and add:
-```
-let nix-colors = builtins.fetchTarball "https://github.com/misterio77/nix-colors/archive/main.tar.gz";
+```nix
+let nix-colors = import (builtins.fetchTarball "https://github.com/misterio77/nix-colors/archive/main.tar.gz");
 ```
 
-Now you can access the color schemes with `(import "${nix-colors}/schemes")`, and the `home-manager` module with `(import "${nix-colors}/module")`.
+Same as with flakes, you can access the color schemes with `nix-colors.colorSchemes`, and the `home-manager` module with `nix-colors.homeManagerModule`.
 
 ## Using
 
 With that done, move to your home manager configuration.
 
-You should import the `nix-colors.homeManagerModule` (or `(import "${nix-colors}/module")`), and set the option `colorscheme` to your preferred scheme, such as `nix-colors.colorSchemes.dracula` (or `(import "${nix-colors}/schemes").dracula`)
+You should import the `nix-colors.homeManagerModule`, and set the option `colorscheme` to your preferred scheme, such as `nix-colors.colorSchemes.dracula`
 
 Here's a quick example on how to use it with, say, a terminal emulator (kitty) and a browser (qutebrowser):
 ```nix

--- a/README.md
+++ b/README.md
@@ -1,53 +1,28 @@
 # Nix Colors
 
-# What?
-This repo is designed to help with Nix(OS) theming, exposing a nix attribute set with 204+ themes to be used as you wish. As well as a [home-manager](https://github.com/nix-community/home-manager) module you can import to globally set your scheme across your entire configuration. We also include four lib functions: for generating a stylish nix wallpaper, for generating a colorscheme from any image, for generating a vim colorscheme, and for a GTK theme!
+# About
+This repo is designed to help with Nix(OS) theming.
 
-It fills pretty much the same usecase of my project [flavours](https://github.com/misterio77/flavours) (and uses it internally), but for your cool reproductible Nix configurations!
+The core feature is an attribute set with 220+ base16 themes to be used as you wish.
 
-## What is base16?
-[Base16](https://github.com/chriskempson/base16) is a standard for defining palettes (schemes), and how each app should be themed (templates). For now we'll just hand you the schemes and let you handle how to use each color. I plan on delivering simple templates as modules soon(tm).
+Plus some other goodies:
+- A [home-manager](https://github.com/nix-community/home-manager) module for globally setting your scheme across your configuration
+- Lib function for generating a scheme from an image (usually your wallpaper), as well as functions for a few common usecases (generating a wallpaper, vim scheme, gtk theme). These are pretty much "addons", being opinionated but fully optional.
 
----
+## Base16?
+[Base16](https://github.com/chriskempson/base16) is a standard for defining palettes (schemes), and how each app should be themed (templates). For now we'll just hand you the schemes and let you handle how to use each color. I plan on delivering simple base templates as modules soon(tm).
 
-# Why?
+# Setup
 
-## Existing solutions?
-Nix is amazing and lets people do stuff their way, but we are often missing a standardized way of doing something, so people end up with lots of different (often incompatible) solutions to the same problem. Probably buried inside their dotfiles or NUR repositories.
-
-Theming is one of them. Based on [rycee's](https://gitlab.com/rycee/nur-expressions/-/tree/master/hm-modules/theme-base16), some of my experience with creating a [base16 theming workflow](https://github.com/misterio77/flavours), and a demand for a easy way to expose multiple schemes, i decided to create this.
-
-Perhaps this could become a standard solution for a common problem.
-
-![relevant xkcd](https://imgs.xkcd.com/comics/standards.png)
-
-## Why not use base16 listings?
-I absolutely love base16, but it's messy. The repos are very fragmented and make difficult to QA and aggregate all the schemes and templates.
-While i appreciate their work, more maintainers are needed to keep up with PRs and improvements, and base16's creator (and [only one that can add more maintainers or move the repo to an org](https://github.com/chriskempson/base16/issues/74)) has no github activity over the last two years.
-
-This repo aims to help with that. By keeping all scheme definitions in one place, we can easily track additions and QA all added schemes, while weeding out low-quality ones.
-
-We include most (if not all) of base16 schemes, including some PRs that are still waiting to be merged. Any contribution there should find its way here soon after.
-
----
-
-# How?
-
-Please keep in mind this repo is WIP and its interface is subject to change (probably won't, but no guarantees). I suggest you either use flakes for reproductibility or pin your fetchurl incantation.
-
-## TL;DR
-
-The general idea is:
+The usual setup looks like this:
 - Either add the repo to your flake inputs (and pass on `nix-colors` to your home config), or use `fetchTarball` to grab it on a legacy setup.
-- Import the module `nix-colors.homeManagerModule`
+- Import the home-manager modulemodule `nix-colors.homeManagerModule`
 - Set the option `colorscheme` to your preferred color scheme (such as `nix-colors.colorSchemes.dracula`)
 - Use `config.colorscheme.colors.base0X` to refer to any of the 16 colors from anywhere!
 
-## Walkthrough
+## Importing
 
-### Importing
-
-#### Flake
+### Flake
 First add `nix-colors` to your flake inputs:
 ```nix
 {
@@ -63,7 +38,7 @@ Then, you need some way to pass this onwards to your `home-manager` configuratio
 Once you do, you can access the color schemes with `nix-colors.colorSchemes`, and the `home-manager` module with `nix-colors.homeManagerModule`.
 
 
-#### Legacy (non-flake)
+### Legacy (non-flake)
 If you're not using flakes, just go to the top of your configuration and add:
 ```
 let nix-colors = builtins.fetchTarball "https://github.com/misterio77/nix-colors/archive/main.tar.gz";
@@ -71,7 +46,7 @@ let nix-colors = builtins.fetchTarball "https://github.com/misterio77/nix-colors
 
 Now you can access the color schemes with `(import "${nix-colors}/schemes")`, and the `home-manager` module with `(import "${nix-colors}/module")`.
 
-### Using
+## Using
 
 With that done, move to your home manager configuration.
 
@@ -86,12 +61,12 @@ Here's a quick example on how to use it with, say, a terminal emulator (kitty) a
 
   colorscheme = nix-colors.colorSchemes.dracula;
 
-  programs = let colorscheme = config.colorscheme; in {
+  programs = {
     kitty = {
       enable = true;
       settings = {
-        foreground = "#${colorscheme.colors.base05}";
-        background = "#${colorscheme.colors.base00}";
+        foreground = "#${config.colorscheme.colors.base05}";
+        background = "#${config.colorscheme.colors.base00}";
         # There's a lot more than just fg and bg...
       };
     };
@@ -99,9 +74,9 @@ Here's a quick example on how to use it with, say, a terminal emulator (kitty) a
       enable = true;
       colors = {
         # Becomes either 'dark' or 'light', based on your colors!
-        webppage.preferred_color_scheme = "${colorscheme.kind}";
-        tabs.bar.bg = "#${colorscheme.colors.base00}";
-        keyhint.fg = "#${colorscheme.colors.base05}";
+        webppage.preferred_color_scheme = "${config.colorscheme.kind}";
+        tabs.bar.bg = "#${config.colorscheme.colors.base00}";
+        keyhint.fg = "#${config.colorscheme.colors.base05}";
         # A lot more...
       };
     };
@@ -111,10 +86,13 @@ Here's a quick example on how to use it with, say, a terminal emulator (kitty) a
 
 If you change `colorscheme` for anything else (say, `nix-colors.colorSchemes.nord`), both qutebrowser and kitty will match the new scheme! Awesome!
 
-## Tips and tricks
+# Lib functions
+[Moved to its own file](lib-usage.md)
 
-### Custom scheme
-Okay, we have 200+ themes, but maybe you want to hardcode your own, no problem! You can just specify it directly:
+# Advanced usage
+
+## Custom scheme
+Okay, we have a lot of schemes, but maybe you want to hardcode (or generate it somehow?) your own, no problem! You can just specify it directly:
 ```nix
 {
   colorscheme = {
@@ -143,7 +121,7 @@ Okay, we have 200+ themes, but maybe you want to hardcode your own, no problem! 
 }
 ```
 
-### Listing all schemes (and registry usage)
+## Listing all schemes (and registry usage)
 Maybe you're working on a cool graphical menu for choosing schemes? Or want to pick a random scheme when you press a button?
 
 No problem with `nix-colors`! The fact that we expose all schemes means you can easily use `nix eval` to list schemes (or even grab and print out their colors), for all your scripting needs.
@@ -157,103 +135,15 @@ This assumes you have nix-colors set as a nix registry. You can easily do it by 
   nix.registry.nix-colors.flake = nix-colors;
 }
 ```
-
-## Lib functions usage
-
-### Generate a scheme from wallpaper
-You can easily use a derivation to generate a scheme from anything, including a picture.
-
-As it's a common usecase, we include a lib function to do just that. Simply call `nix-colors.lib` (passing your pkgs attribute), and it's at your disposal:
-```nix
-{ pkgs, config, nix-colors, ... }:
-
-# This will bring colorschemeFromPicture into scope
-with nix-colors.lib { inherit pkgs; };
-{
-  colorscheme = colorschemeFromPicture {
-    path = ./wallpapers/example.png;
-    kind = "light";
-  };
-}
-```
-All done, just use `config.colorscheme` as usual!
-
-### Generate a wallpaper from a scheme
-Of course, you can go the other way around too. You can easily use your chosen colorscheme in any sort of derivations.
-
-We include a lib function for generating a stylish nix-themed wallpaper matching your scheme. As above, call `nix-colors.lib { inherit pkgs; }`, and use the lib this way:
-```nix
-{ pkgs, config, nix-colors, ... }:
-
-# This will bring nixWallpaperFromScheme into scope
-with nix-colors.lib { inherit pkgs; };
-{
-  colorscheme = nix-colors.colorSchemes.tokyonight;
-
-  wallpaper = nixWallpaperFromScheme {
-    scheme = config.colorscheme;
-    width = 1920;
-    height = 1080;
-    logoScale = 4.0;
-  };
-}
-```
-This assumes you have an [option named wallpaper](https://github.com/Misterio77/nix-config/blob/7aef57a5a84a176da872665ade96f9ab586474db/modules/home-manager/wallpaper.nix), of course. If so, you can then use `config.wallpaper` wherever you need to you use your wallpaper.
-
-If you don't, just make `wallpaper` a `let` binding instead, or ust use `nixWallpaperFromScheme` directly where it'll be used.
-
-[Here's example usage](https://github.com/Misterio77/nix-config/blob/3d2da71578b930ea065a61a73fc26155482ab438/users/misterio/rice.nix) for both this and scheme generation.
-
-### Generate a GTK theme from a scheme
-We also include a lib function for generating a (Materia based, maybe more options in the future) GTK (plus gnome shell and cinnamon) theme from a scheme.
-
-Just call our lib same as above, and use `gtkThemeFromScheme`:
-
-```nix
-{ pkgs, config, nix-colors, ... }:
-
-with nix-colors.lib { inherit pkgs; };
-{
-  colorscheme = nix-colors.colorSchemes.spaceduck;
-
-  gtk.theme = {
-    name = "${config.colorscheme.slug}";
-    package = gtkThemeFromScheme {
-      scheme = config.colorscheme;
-    };
-  };
-}
-```
-
-### Vim colorscheme from scheme
-We also have a lib function for a (neo)vim colorscheme.
-
-Same as before, call our lib and add the package to `programs.vim.plugins` or `programs.neovim.plugins` (optionally, add `colorscheme nix-${slug}` to your config so the colorscheme applies on startup):
-```nix
-{ pkgs, config, nix-colors, ... }:
-
-with nix-colors.lib { inherit pkgs; };
-
-{
-  programs.neovim.plugins = [
-    {
-      plugin = vimThemeFromScheme { scheme = config.colorscheme; };
-      config = "colorscheme nix-${config.colorscheme.slug}";
-    }
-  ];
-}
-```
-
 # Thanks
 
 Special thanks to rycee for most of this repo's inspiration, plus for the amazing home-manager.
 
 Huge thanks for everyone involved with base16.
 
-And extra special thanks for my folks at the NixOS Brasil Telegram group, for willing to try this out!
+Extra special thanks for my folks at the NixOS Brasil Telegram group, for willing to try this out!
 
 
 # Roadmap
-- Add support for base24 (which is backwards compatible with both base16 schemes and templates)
-- Add modules for pre-configured application theming
-- ???
+- Add support for base24 (which is backwards compatible with base16)
+- Add more functions for pre-configured application theming (i'd love your help!)

--- a/README.md
+++ b/README.md
@@ -33,18 +33,17 @@ First add `nix-colors` to your flake inputs:
 }
 ```
 
-Then, you need some way to pass this onwards to your `home-manager` configuration. You should use `extraSpecialArgs` for this (if you haven't done this before, feel free to ask for my help).
-
-Once you do, you can access the color schemes with `nix-colors.colorSchemes`, and the `home-manager` module with `nix-colors.homeManagerModule`.
+Then, you need some way to pass this onwards to your `home-manager` configuration. You should use `extraSpecialArgs` for this, for example:
 
 
 ### Legacy (non-flake)
-If you're not using flakes, just go to the top of your configuration and add:
-```nix
-let nix-colors = import (builtins.fetchTarball "https://github.com/misterio77/nix-colors/archive/main.tar.gz");
+If you're not using flakes, the most convenient method is adding nix-colors to your channels:
+```
+nix-channel --add https://github.com/misterio77/nix-colors/archive/main.tar.gz nix-colors
+nix-channel --update
 ```
 
-Same as with flakes, you can access the color schemes with `nix-colors.colorSchemes`, and the `home-manager` module with `nix-colors.homeManagerModule`.
+Then, at the top of your config file(s) add `nix-colors ? <nix-colors>` as arguments (instead of just `nix-colors`).
 
 ## Using
 
@@ -135,6 +134,9 @@ This assumes you have nix-colors set as a nix registry. You can easily do it by 
   nix.registry.nix-colors.flake = nix-colors;
 }
 ```
+
+It is quite nice to add all your flake inputs as system registries, [here's an example on how to do it](https://github.com/Misterio77/nix-starter-config/blob/minimal/configuration.nix#L67).
+
 # Thanks
 
 Special thanks to rycee for most of this repo's inspiration, plus for the amazing home-manager.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+rec {
+  lib = import ./lib;
+  colorSchemes = import ./schemes;
+  homeManagerModules.colorscheme = import ./module;
+  homeManagerModule = homeManagerModules.colorscheme;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,5 @@
   description =
     "Collection of nix-compatible color schemes, and a home-manager module to make theming easier.";
 
-  outputs = { self }: {
-    lib = import ./lib;
-    colorSchemes = import ./schemes;
-    homeManagerModules.colorscheme = import ./module;
-    homeManagerModule = self.homeManagerModules.colorscheme;
-  };
+  outputs = { self }: import ./.;
 }

--- a/lib-usage.md
+++ b/lib-usage.md
@@ -1,0 +1,86 @@
+# Lib functions usage
+
+Here's a few of our lib functions documented. They're designed to be optional convenience for some common scheme usage.
+
+## Generate a scheme from wallpaper
+You can easily use a derivation to generate a scheme from anything, including a picture.
+
+As it's a common usecase, we include a lib function to do just that. Simply call `nix-colors.lib` (passing your pkgs attribute), and it's at your disposal:
+```nix
+{ pkgs, config, nix-colors, ... }:
+
+with nix-colors.lib { inherit pkgs; };
+{
+  colorscheme = colorschemeFromPicture {
+    path = ./wallpapers/example.png;
+    kind = "light";
+  };
+}
+```
+All done, just use `config.colorscheme` as usual!
+
+### Generate a wallpaper from a scheme
+Of course, you can go the other way around too. You can easily use your chosen colorscheme in any sort of derivations.
+
+We include a lib function for generating a stylish nix-themed wallpaper matching your scheme.
+```nix
+{ pkgs, config, nix-colors, ... }:
+
+with nix-colors.lib { inherit pkgs; };
+{
+  colorscheme = nix-colors.colorSchemes.tokyonight;
+
+  wallpaper = nixWallpaperFromScheme {
+    scheme = config.colorscheme;
+    width = 1920;
+    height = 1080;
+    logoScale = 4.0;
+  };
+}
+```
+This assumes you have an [option named wallpaper](https://github.com/Misterio77/nix-config/blob/7aef57a5a84a176da872665ade96f9ab586474db/modules/home-manager/wallpaper.nix), of course. If so, you can then use `config.wallpaper` wherever you need to you use your wallpaper.
+
+If you don't, just make `wallpaper` a `let` binding instead, or ust use `nixWallpaperFromScheme` directly where it'll be used.
+
+[Here's example usage](https://github.com/Misterio77/nix-config/blob/3d2da71578b930ea065a61a73fc26155482ab438/users/misterio/rice.nix) for both this and scheme generation.
+
+### Generate a GTK theme from a scheme
+We also include a lib function for generating a (Materia based, maybe more options in the future) GTK (plus gnome shell and cinnamon) theme from a scheme.
+
+Just call our lib same as above, and use `gtkThemeFromScheme`:
+
+```nix
+{ pkgs, config, nix-colors, ... }:
+
+with nix-colors.lib { inherit pkgs; };
+{
+  colorscheme = nix-colors.colorSchemes.spaceduck;
+
+  gtk.theme = {
+    name = "${config.colorscheme.slug}";
+    package = gtkThemeFromScheme {
+      scheme = config.colorscheme;
+    };
+  };
+}
+```
+
+### Vim colorscheme from scheme
+We also have a lib function for a (neo)vim colorscheme.
+
+Same as before, call our lib and add the package to `programs.vim.plugins` or `programs.neovim.plugins` (optionally, add `colorscheme nix-${slug}` to your config so the colorscheme applies on startup):
+```nix
+{ pkgs, config, nix-colors, ... }:
+
+with nix-colors.lib { inherit pkgs; };
+
+{
+  programs.neovim.plugins = [
+    {
+      plugin = vimThemeFromScheme { scheme = config.colorscheme; };
+      config = "colorscheme nix-${config.colorscheme.slug}";
+    }
+  ];
+}
+```
+

--- a/lib-usage.md
+++ b/lib-usage.md
@@ -3,9 +3,8 @@
 Here's a few of our lib functions documented. They're designed to be optional convenience for some common scheme usage.
 
 ## Generate a scheme from wallpaper
-You can easily use a derivation to generate a scheme from anything, including a picture.
+Simply call `nix-colors.lib` (passing your `pkgs`), and use it like this:
 
-As it's a common usecase, we include a lib function to do just that. Simply call `nix-colors.lib` (passing your pkgs attribute), and it's at your disposal:
 ```nix
 { pkgs, config, nix-colors, ... }:
 
@@ -22,7 +21,7 @@ All done, just use `config.colorscheme` as usual!
 ### Generate a wallpaper from a scheme
 Of course, you can go the other way around too. You can easily use your chosen colorscheme in any sort of derivations.
 
-We include a lib function for generating a stylish nix-themed wallpaper matching your scheme.
+Our lib function generates a stylish nix-themed wallpaper matching your scheme.
 ```nix
 { pkgs, config, nix-colors, ... }:
 
@@ -38,17 +37,12 @@ with nix-colors.lib { inherit pkgs; };
   };
 }
 ```
-This assumes you have an [option named wallpaper](https://github.com/Misterio77/nix-config/blob/7aef57a5a84a176da872665ade96f9ab586474db/modules/home-manager/wallpaper.nix), of course. If so, you can then use `config.wallpaper` wherever you need to you use your wallpaper.
+This assumes you have an [option named wallpaper](https://github.com/Misterio77/nix-config/blob/7aef57a5a84a176da872665ade96f9ab586474db/modules/home-manager/wallpaper.nix). If so, you can then use `config.wallpaper` wherever you need to you use your wallpaper.
 
 If you don't, just make `wallpaper` a `let` binding instead, or ust use `nixWallpaperFromScheme` directly where it'll be used.
 
-[Here's example usage](https://github.com/Misterio77/nix-config/blob/3d2da71578b930ea065a61a73fc26155482ab438/users/misterio/rice.nix) for both this and scheme generation.
-
 ### Generate a GTK theme from a scheme
-We also include a lib function for generating a (Materia based, maybe more options in the future) GTK (plus gnome shell and cinnamon) theme from a scheme.
-
-Just call our lib same as above, and use `gtkThemeFromScheme`:
-
+We also include a lib function for generating a (Materia based, maybe there'll be more options in the future) GTK theme from a scheme.
 ```nix
 { pkgs, config, nix-colors, ... }:
 
@@ -68,7 +62,7 @@ with nix-colors.lib { inherit pkgs; };
 ### Vim colorscheme from scheme
 We also have a lib function for a (neo)vim colorscheme.
 
-Same as before, call our lib and add the package to `programs.vim.plugins` or `programs.neovim.plugins` (optionally, add `colorscheme nix-${slug}` to your config so the colorscheme applies on startup):
+Same as before, call our lib and add the package to `programs.vim.plugins` or `programs.neovim.plugins` like this (the `colorscheme` setting applies it on startup, you can [use neovim remote](https://github.com/Misterio77/nix-config/blob/main/users/misterio/features/cli/nvim/default.nix#L82) to re-source your config when it's updated):
 ```nix
 { pkgs, config, nix-colors, ... }:
 
@@ -83,4 +77,3 @@ with nix-colors.lib { inherit pkgs; };
   ];
 }
 ```
-


### PR DESCRIPTION
This should make the README quite easier to read and follow.

I've also added the stuff the flake exports to a `default.nix` attrset, making it easier to use for non-flakers. The docs referring to fetchTarball was replaced with nix channel instructions.