### PR TITLE
Add shellThemeFromScheme function to lib-contrib

### DIFF
--- a/lib/contrib/default.nix
+++ b/lib/contrib/default.nix
@@ -43,4 +43,14 @@ rec {
   #   }
   # ];
   vimThemeFromScheme = import ./vim-theme.nix { inherit pkgs; };
+
+  # Takes a scheme, ouputs a script that applies this scheme to the current shell.
+  #
+  # Example:
+  # programs.fish = {
+  #   interactiveShellInit = ''
+  #     sh ${shellThemeFromScheme { scheme = config.colorScheme; }}
+  #   '';
+  # };
+  shellThemeFromScheme = import ./shell-theme.nix { inherit pkgs; };
 }

--- a/lib/contrib/shell-theme.nix
+++ b/lib/contrib/shell-theme.nix
@@ -4,6 +4,8 @@ with scheme.colors;
 pkgs.writeShellScript "shell-theme-${scheme.slug}.sh" ''
   if [ "''${TERM%%[-.]*}" = "screen" ]; then
       apply_color() { echo -ne "\033P\033]$@\007\033\\"; }
+  elif [ -n "$TMUX" ]; then
+      apply_color() { echo -ne "\033Ptmux;\033\033]$@\033\033\\\033\\"; }
   else
       apply_color() { echo -ne "\033]$@\033\\"; }
   fi
@@ -39,4 +41,7 @@ pkgs.writeShellScript "shell-theme-${scheme.slug}.sh" ''
 
   # cursor
   apply_color "12;#${base05}" # base00
+
+  # tmux terminal border
+  apply_color "708;#${base00}\00
 ''

--- a/lib/contrib/shell-theme.nix
+++ b/lib/contrib/shell-theme.nix
@@ -1,0 +1,42 @@
+{ pkgs }: { scheme }:
+# Source: https://git.sr.ht/~misterio/shellcolord
+with scheme.colors;
+pkgs.writeShellScript "shell-theme-${scheme.slug}.sh" ''
+  if [ "''${TERM%%[-.]*}" = "screen" ]; then
+      apply_color() { echo -ne "\033P\033]$@\007\033\\"; }
+  else
+      apply_color() { echo -ne "\033]$@\033\\"; }
+  fi
+
+  # 16 color space
+  apply_color "4;0;#${base00}" # black
+  apply_color "4;1;#${base08}" # red
+  apply_color "4;2;#${base0B}" # green
+  apply_color "4;3;#${base0A}" # yellow
+  apply_color "4;4;#${base0D}" # blue
+  apply_color "4;5;#${base0E}" # magenta
+  apply_color "4;6;#${base0C}" # cyan
+  apply_color "4;7;#${base05}" # white
+  apply_color "4;8;#${base03}" # bright black
+  apply_color "4;9;#${base08}" # bright red
+  apply_color "4;10;#${base0B}" # bright green
+  apply_color "4;11;#${base0A}" # bright yellow
+  apply_color "4;12;#${base0D}" # bright blue
+  apply_color "4;13;#${base0E}" # bright magenta
+  apply_color "4;14;#${base0C}" # bright cyan
+  apply_color "4;15;#${base07}" # bright white
+  # 256 color space
+  apply_color "4;16;#${base09}" # base09
+  apply_color "4;17;#${base0F}" # base0f
+  apply_color "4;18;#${base01}" # base01
+  apply_color "4;19;#${base02}" # base02
+  apply_color "4;20;#${base04}" # base04
+  apply_color "4;21;#${base06}" # base06
+
+  # fg and bg
+  apply_color "10;#${base05}" # base05
+  apply_color "11;#${base00}" # base00
+
+  # cursor
+  apply_color "12;#${base05}" # base00
+''


### PR DESCRIPTION
Adds a Nix function which generates a shell script that applies a given color scheme to the current shell.

Inspired by https://git.sr.ht/~misterio/shellcolord and https://github.com/Misterio77/nix-colors/pull/14