### PR TITLE
Fix darwin incompatibility caused by regex use

### DIFF
--- a/lib/core/schemeFromYAML.nix
+++ b/lib/core/schemeFromYAML.nix
@@ -36,7 +36,7 @@ let
         else elemAt match 0;
       attrLine = line:
         let
-          match = builtins.match "([^ :]+): *(.*?) *" line;
+          match = builtins.match "([^ :]+): *(.*)" line;
         in
         if match == null then throw ''YAML parse failed: "${line}"''
         else nameValuePair (elemAt match 0) (parseString (elemAt match 1));

--- a/lib/core/schemeFromYAML.nix
+++ b/lib/core/schemeFromYAML.nix
@@ -25,7 +25,7 @@ let
   # From https://github.com/arcnmx/nixexprs
   fromYAML = yaml:
     let
-      stripLine = line: elemAt (builtins.match "([^#]*)(#.*|)" line) 0;
+      stripLine = line: elemAt (builtins.match "(^[^#]*)($|#.*$)" line) 0;
       usefulLine = line: builtins.match "[ \\t]*" line == null;
       parseString = token:
         let


### PR DESCRIPTION
Fixes https://github.com/Misterio77/nix-colors/issues/17

It seems nix's regex implementation has [some platform differences](https://github.com/NixOS/nix/issues/1537). This PR apparently fixes them with a little regex tweaking.

We'll have tests soon(ish), should this kind of problems will not go unnoticed.