### PR TITLE
contrib/shell-theme: fix issue with nix-copy-closure and nix remote builders

### DIFF
--- a/lib/contrib/shell-theme.nix
+++ b/lib/contrib/shell-theme.nix
@@ -2,7 +2,9 @@
 # Source: https://git.sr.ht/~misterio/shellcolord
 with scheme.colors;
 pkgs.writeShellScript "shell-theme-${scheme.slug}.sh" /* bash */ ''
-  if [ "''${TERM%%[-.]*}" = "screen" ]; then
+  if [ "''${TERM%%[-.]*}" = "dumb" ]; then
+    apply_color() { true; }
+  elif [ "''${TERM%%[-.]*}" = "screen" ]; then
       apply_color() { echo -ne "\033P\033]$@\007\033\\"; }
   elif [ -n "$TMUX" ]; then
       apply_color() { echo -ne "\033Ptmux;\033\033]$@\033\033\\\033\\"; }


### PR DESCRIPTION
A problem I had with this module is that I have this set up with home-manager and if I setup home-manager on a machine it gives some weird errors when doing remote builds or nix-copy-closures on them. Weirdly enough the error says about an invalid value returned by the builder and funnily enough it's the color sequence of my colorscheme.

It seems that these extra echos are breaking Nix so I had to find a way to [not run these echos if running in an SSH session](https://github.com/lucasew/nixcfg/commit/80bf3dbdc2ae2c5ef070dc718087f92e5954669c). Unfortunately, it's less convenient because I have to initiate a bash session in an environment that `SSH_SESSION` is unset to apply the colors.

Then I copied my original bashrc to another file and added a `env | sort > /tmp/somefile.txt` and sourced the original bashrc, started a bash session, then moved that txt file to another name, then ran nix-copy-closure to check what is different between these SSH sessions and found out that Nix, when logging in sets up TERM to `dumb` and just added a check in the script to no-op if TERM is `dumb`.

Now it's fixed and colorful, well, `classic-dark` is not so colorful. But it's fixed.