### PR TITLE
Fix warning when using textMateThemeFromScheme from lib-contrib

### DIFF
--- a/lib/contrib/textmate-theme.nix
+++ b/lib/contrib/textmate-theme.nix
@@ -45,7 +45,7 @@ let
         note: Supported types are: ${lib.concatStringsSep ", " (builtins.attrNames handlers)}.
       '';
 
-  colorsDict = with scheme.colors; {
+  colorsDict = with scheme.palette; {
     name = "Generated base16 theme based on ${scheme.name}";
     semanticClass = "theme.base16.${scheme.slug}";
     colorSpaceName = "sRGB";


### PR DESCRIPTION
When using the textMateThemeFromScheme function from lib-contrib, a warning is generated:

```
trace: Obsolete option `colorScheme.colors' is used. It was renamed to `colorScheme.palette'.
```

This PR fixes this issue.