### PR TITLE
contrib/shell-theme: make POSIX compliant

### DIFF
--- a/lib/contrib/shell-theme.nix
+++ b/lib/contrib/shell-theme.nix
@@ -14,7 +14,7 @@ pkgs.writeShellScript "shell-theme-${scheme.slug}.sh" /* bash */ ''
 
   apply_color_tty() { echo -ne "\e]P$@"; }
 
-  if [ "$TERM" == "linux" ]; then
+  if [ "$TERM" = "linux" ]; then
     # When running in a tty
     apply_color_tty "0${base00}" # black
     apply_color_tty "1${base08}" # red


### PR DESCRIPTION
'==' is bash operator and not available in the standard /bin/sh. Fixes #33.